### PR TITLE
Add mandatory checks in root initialization

### DIFF
--- a/mosaic/src/errors.rs
+++ b/mosaic/src/errors.rs
@@ -21,6 +21,7 @@ pub enum MosaicError {
     ProvidedDestinationProgramMismatchWithRootDestinationProgram, /* TODO: make test for this case */
     ThresholdCanNotBeHigherThanLenOfOperators,
     OperatorsCountMustBePositive,
+    ThresholdCanNotBeZero,
 }
 
 impl std::fmt::Display for MosaicError {
@@ -89,6 +90,9 @@ impl std::fmt::Display for MosaicError {
             }
             MosaicError::OperatorsCountMustBePositive => {
                 write!(f, "there must be at least one operator")
+            }
+            MosaicError::ThresholdCanNotBeZero => {
+                write!(f, "threshold can not be zero")
             }
         }
     }

--- a/mosaic/src/instructions/init_root.rs
+++ b/mosaic/src/instructions/init_root.rs
@@ -109,12 +109,18 @@ impl<'info> InitializeOperators<'info> {
 
     #[must_use]
     fn mandatory_checks(ix_data: &InitializeRootIxData) -> Result<(), ProgramError> {
-        if ix_data.operators.len() == 0 {
+        if ix_data.operators.is_empty() {
             return Err(MosaicError::OperatorsCountMustBePositive.into());
         }
-        if ix_data.threshold as usize > ix_data.operators.len() || ix_data.threshold == 0 {
+
+        if ix_data.threshold == 0 {
+            return Err(MosaicError::ThresholdCanNotBeZero.into());
+        }
+
+        if ix_data.threshold as usize > ix_data.operators.len() {
             return Err(MosaicError::ThresholdCanNotBeHigherThanLenOfOperators.into());
         }
+
         Ok(())
     }
 }

--- a/mosaic/tests/init_root_failures.rs
+++ b/mosaic/tests/init_root_failures.rs
@@ -258,11 +258,6 @@ fn test_initialize_root_zero_operators_failure() {
     let (system_program, system_account) = mollusk_svm::program::keyed_account_for_system_program();
 
     let operators = Operators::new(1, system_program);
-    let operators_pubkey: Vec<Pubkey> = operators
-        .operators
-        .iter()
-        .map(|operator| operator.0)
-        .collect();
     let (signer, signer_account) = operators.operators[0].clone();
 
     let (root_pda, root_pda_bump) =
@@ -271,7 +266,7 @@ fn test_initialize_root_zero_operators_failure() {
 
     let ix_data = InitializeRootIxData {
         operators: vec![], // issue here
-        threshold: 0,
+        threshold: 1,
         bump: root_pda_bump,
         destination_program: DESTINATION_PROGRAM_ID,
     };
@@ -299,6 +294,57 @@ fn test_initialize_root_zero_operators_failure() {
         ],
         &[Check::err(ProgramError::Custom(
             MosaicError::OperatorsCountMustBePositive as u32,
+        ))],
+    );
+}
+
+#[test]
+fn test_initialize_root_zero_threshold_failure() {
+    let mollusk = Mollusk::new(&PROGRAM_ID, MOSAIC_BINARY_PATH);
+    let (system_program, system_account) = mollusk_svm::program::keyed_account_for_system_program();
+
+    let operators = Operators::new(1, system_program);
+    let operators_pubkey: Vec<Pubkey> = operators
+        .operators
+        .iter()
+        .map(|operator| operator.0)
+        .collect();
+    let (signer, signer_account) = operators.operators[0].clone();
+
+    let (root_pda, root_pda_bump) =
+        solana_sdk::pubkey::Pubkey::find_program_address(&[ROOT_PDA], &PROGRAM_ID);
+    let root_account = AccountSharedData::new(0, 0, &system_program);
+
+    let ix_data = InitializeRootIxData {
+        operators: operators_pubkey,
+        threshold: 0, // issue here
+        bump: root_pda_bump,
+        destination_program: DESTINATION_PROGRAM_ID,
+    };
+    let data = [
+        vec![ProgramIx::InitializeOperators as u8],
+        to_vec(&ix_data).unwrap(),
+    ]
+    .concat();
+
+    let instruction = Instruction::new_with_bytes(
+        PROGRAM_ID,
+        &data,
+        vec![
+            AccountMeta::new(signer.into(), true),
+            AccountMeta::new(root_pda, false),
+            AccountMeta::new_readonly(system_program, false),
+        ],
+    );
+    let _result: mollusk_svm::result::InstructionResult = mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (signer.into(), signer_account.clone().into()),
+            (root_pda, root_account.clone().into()),
+            (system_program, system_account.clone()),
+        ],
+        &[Check::err(ProgramError::Custom(
+            MosaicError::ThresholdCanNotBeZero as u32,
         ))],
     );
 }


### PR DESCRIPTION
### Description
Added mandatory checks around threshold and operators count during root initialization.

### Summary of changes
- Root initialization now validates that the threshold does not exceed the operator count
- Returns `ThresholdCanNotBeHigherThanLenOfOperators` error when the threshold exceeds the operator count
- Returns `ThresholdCanNotBeZero` error when the threshold is zero
- Returns `OperatorsCountMustBePositive` error when zero operators are provided
- Added tests for failure scenarios