### PR TITLE
Add max operators limit

### DIFF
--- a/mosaic/src/errors.rs
+++ b/mosaic/src/errors.rs
@@ -22,6 +22,7 @@ pub enum MosaicError {
     ThresholdCanNotBeHigherThanLenOfOperators,
     OperatorsCountMustBePositive,
     ThresholdCanNotBeZero,
+    ReachedOperatorsLimit,
 }
 
 impl std::fmt::Display for MosaicError {
@@ -93,6 +94,9 @@ impl std::fmt::Display for MosaicError {
             }
             MosaicError::ThresholdCanNotBeZero => {
                 write!(f, "threshold can not be zero")
+            }
+            MosaicError::ReachedOperatorsLimit => {
+                write!(f, "max operators limit reached")
             }
         }
     }

--- a/mosaic/src/instructions/init_root.rs
+++ b/mosaic/src/instructions/init_root.rs
@@ -113,6 +113,10 @@ impl<'info> InitializeOperators<'info> {
             return Err(MosaicError::OperatorsCountMustBePositive.into());
         }
 
+        if ix_data.operators.len() > 20 {
+            return Err(MosaicError::ReachedOperatorsLimit.into());
+        }
+
         if ix_data.threshold == 0 {
             return Err(MosaicError::ThresholdCanNotBeZero.into());
         }

--- a/mosaic/tests/init_root.rs
+++ b/mosaic/tests/init_root.rs
@@ -3,11 +3,11 @@ mod common;
 use {
     borsh::to_vec,
     common::*,
-    mollusk_svm::{result::Check, Mollusk},
+    mollusk_svm::{Mollusk, result::Check},
 };
 
 use mosaic::{
-    instructions::{init_root::InitializeRootIxData, Instruction as ProgramIx},
+    instructions::{Instruction as ProgramIx, init_root::InitializeRootIxData},
     seeds::ROOT_PDA,
     state::root::Root,
 };
@@ -15,7 +15,7 @@ use mosaic::{
 use solana_sdk::{
     account::AccountSharedData,
     instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey
+    pubkey::Pubkey,
 };
 
 #[test]
@@ -24,6 +24,65 @@ fn test_initialize_root() {
     let (system_program, system_account) = mollusk_svm::program::keyed_account_for_system_program();
 
     let operators = Operators::new(3, system_program);
+    let operators_pubkey: Vec<Pubkey> = operators
+        .operators
+        .iter()
+        .map(|operator| operator.0)
+        .collect();
+    let (signer, signer_account) = operators.operators[0].clone();
+
+    let (root_pda, root_pda_bump) =
+        solana_sdk::pubkey::Pubkey::find_program_address(&[ROOT_PDA], &PROGRAM_ID);
+    let root_account = AccountSharedData::new(0, 0, &system_program);
+
+    let ix_data = InitializeRootIxData {
+        operators: operators_pubkey.clone(),
+        threshold: operators.threshold,
+        bump: root_pda_bump,
+        destination_program: DESTINATION_PROGRAM_ID,
+    };
+    let data = [
+        vec![ProgramIx::InitializeOperators as u8],
+        to_vec(&ix_data).unwrap(),
+    ]
+    .concat();
+
+    let instruction = Instruction::new_with_bytes(
+        PROGRAM_ID,
+        &data,
+        vec![
+            AccountMeta::new(signer.into(), true),
+            AccountMeta::new(root_pda, false),
+            AccountMeta::new_readonly(system_program, false),
+        ],
+    );
+    let result: mollusk_svm::result::InstructionResult = mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (signer.into(), signer_account.clone().into()),
+            (root_pda, root_account.clone().into()),
+            (system_program, system_account.clone()),
+        ],
+        &[
+            Check::success(),
+            Check::account(&root_pda).owner(&PROGRAM_ID).build(),
+        ],
+    );
+    let updated_root_pda_account = result.get_account(&root_pda).unwrap();
+    let parsed_root_pda_data = borsh::from_slice::<Root>(&updated_root_pda_account.data).unwrap();
+
+    assert!(parsed_root_pda_data.bump == root_pda_bump);
+    assert!(parsed_root_pda_data.last_id == 0);
+    assert!(parsed_root_pda_data.threshold == operators.threshold);
+    assert!(parsed_root_pda_data.operators == operators_pubkey);
+}
+
+#[test]
+fn test_initialize_root_huge_operators_list() {
+    let mollusk = Mollusk::new(&PROGRAM_ID, MOSAIC_BINARY_PATH);
+    let (system_program, system_account) = mollusk_svm::program::keyed_account_for_system_program();
+
+    let operators = Operators::new(20, system_program);
     let operators_pubkey: Vec<Pubkey> = operators
         .operators
         .iter()

--- a/mosaic/tests/init_root_failures.rs
+++ b/mosaic/tests/init_root_failures.rs
@@ -348,3 +348,54 @@ fn test_initialize_root_zero_threshold_failure() {
         ))],
     );
 }
+
+#[test]
+fn test_initialize_root_over_max_operators_failure() {
+    let mollusk = Mollusk::new(&PROGRAM_ID, MOSAIC_BINARY_PATH);
+    let (system_program, system_account) = mollusk_svm::program::keyed_account_for_system_program();
+
+    let operators = Operators::new(21, system_program);
+    let (signer, signer_account) = operators.operators[0].clone();
+    let operators_pubkey: Vec<Pubkey> = operators
+        .operators
+        .iter()
+        .map(|operator| operator.0)
+        .collect();
+
+    let (root_pda, root_pda_bump) =
+        solana_sdk::pubkey::Pubkey::find_program_address(&[ROOT_PDA], &PROGRAM_ID);
+    let root_account = AccountSharedData::new(0, 0, &system_program);
+
+    let ix_data = InitializeRootIxData {
+        operators: operators_pubkey, // issue here
+        threshold: 1,
+        bump: root_pda_bump,
+        destination_program: DESTINATION_PROGRAM_ID,
+    };
+    let data = [
+        vec![ProgramIx::InitializeOperators as u8],
+        to_vec(&ix_data).unwrap(),
+    ]
+    .concat();
+
+    let instruction = Instruction::new_with_bytes(
+        PROGRAM_ID,
+        &data,
+        vec![
+            AccountMeta::new(signer.into(), true),
+            AccountMeta::new(root_pda, false),
+            AccountMeta::new_readonly(system_program, false),
+        ],
+    );
+    let _result: mollusk_svm::result::InstructionResult = mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (signer.into(), signer_account.clone().into()),
+            (root_pda, root_account.clone().into()),
+            (system_program, system_account.clone()),
+        ],
+        &[Check::err(ProgramError::Custom(
+            MosaicError::ReachedOperatorsLimit as u32,
+        ))],
+    );
+}


### PR DESCRIPTION
### Description
To prevent possible issues with large operator count, a new limit of 20 operators has been set.

### Summary of changes
- Returns `ReachedOperatorsLimit` error if the operator count exceeds 20
- Tests to cover both success and failure scenarios for large operator set