### PR TITLE
Introduce PackUnpack trait

### DIFF
--- a/mosaic/Cargo.lock
+++ b/mosaic/Cargo.lock
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "mosaic"
-version = "0.5.2"
+version = "0.5.5"
 dependencies = [
  "borsh",
  "mollusk-svm",

--- a/mosaic/Cargo.toml
+++ b/mosaic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mosaic"
 description = "multi-signature governance solution that enables threshold-based execution against solana programs"
-version = "0.5.2"
+version = "0.5.5"
 edition = "2024"
 
 [lib]

--- a/mosaic/src/instructions/execute.rs
+++ b/mosaic/src/instructions/execute.rs
@@ -5,6 +5,7 @@ use crate::{
     invoke_signed_dynamic,
     seeds::ROOT_PDA,
     state::{
+        PackUnpack,
         root::Root,
         signing_session::{InstructionAccount, SigningSession},
     },
@@ -105,7 +106,7 @@ impl<'info> TryFrom<(&'info [AccountView], &'info [u8])> for Execute<'info> {
 impl<'info> Execute<'info> {
     pub fn handler(&mut self) -> ProgramResult {
         let root_account = self.accounts.root.try_borrow()?;
-        let root_data = Root::deserialize(&root_account)?;
+        let root_data = Root::unpack(&root_account)?;
         let root_pda = Address::create_program_address(&[ROOT_PDA, &[root_data.bump]], &ID.into())
             .map_err(|_| ProgramError::InvalidSeeds)?;
 
@@ -115,7 +116,7 @@ impl<'info> Execute<'info> {
 
         let signing_data = {
             let signing_account = self.accounts.signing_session.try_borrow()?;
-            SigningSession::deserialize(&signing_account)?
+            SigningSession::unpack(&signing_account)?
         };
 
         root_pda_check(&self.accounts.root.address(), &[root_data.bump])?;
@@ -178,7 +179,7 @@ impl<'info> Execute<'info> {
         let mut signing_data = signing_data;
         signing_data.progress_phase_checked()?; /* set signing session phase to executed */
 
-        let (serialized_data, serialized_len) = signing_data.serialize()?;
+        let (serialized_data, serialized_len) = signing_data.pack()?;
         let mut signing_account = self.accounts.signing_session.try_borrow_mut()?;
         signing_account[..serialized_len].copy_from_slice(&serialized_data);
 

--- a/mosaic/src/instructions/init_root.rs
+++ b/mosaic/src/instructions/init_root.rs
@@ -1,5 +1,9 @@
 use crate::{
-    ID, errors::MosaicError, instructions::root_pda_check, seeds::ROOT_PDA, state::root::Root,
+    ID,
+    errors::MosaicError,
+    instructions::root_pda_check,
+    seeds::ROOT_PDA,
+    state::{PackUnpack, root::Root},
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use pinocchio::{
@@ -88,7 +92,7 @@ impl<'info> InitializeOperators<'info> {
         let root_seeds = [Seed::from(ROOT_PDA), Seed::from(&root_ix_data_bump)];
         let cpi_signer = Signer::from(&root_seeds);
 
-        let (root_data, root_data_len) = Root::init(self.instruction_data.clone()).serialize()?;
+        let (root_data, root_data_len) = Root::init(self.instruction_data.clone()).pack()?;
 
         // create account
         pinocchio_system::instructions::CreateAccount {

--- a/mosaic/src/instructions/init_signing_session.rs
+++ b/mosaic/src/instructions/init_signing_session.rs
@@ -3,7 +3,7 @@ use crate::{
     errors::MosaicError,
     instructions::{root_pda_check, signing_session_pda_check},
     seeds::SIGNING_SESSION_PDA,
-    state::{root::Root, signing_session::SigningSession},
+    state::{PackUnpack, root::Root, signing_session::SigningSession},
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use pinocchio::{
@@ -99,7 +99,7 @@ impl<'info> TryFrom<(&'info [AccountView], &'info [u8])> for InitializeSigningSe
 impl<'info> InitializeSigningSession<'info> {
     pub fn handler(&mut self) -> ProgramResult {
         let mut root_account = self.accounts.root.try_borrow_mut()?;
-        let mut root_data = Root::deserialize(&root_account)?;
+        let mut root_data = Root::unpack(&root_account)?;
 
         root_data.increment_last_id()?;
 
@@ -129,7 +129,7 @@ impl<'info> InitializeSigningSession<'info> {
             root_data.last_id,
             self.accounts.root.address(),
         )
-        .serialize()?;
+        .pack()?;
 
         // create signing session account
         pinocchio_system::instructions::CreateAccount {
@@ -142,7 +142,7 @@ impl<'info> InitializeSigningSession<'info> {
         .invoke_signed(&[cpi_signer])?;
 
         // write updated root state
-        let (updated_root_data, updated_root_data_len) = root_data.serialize()?;
+        let (updated_root_data, updated_root_data_len) = root_data.pack()?;
         root_account[..updated_root_data_len].copy_from_slice(&updated_root_data);
 
         // write to signing session account

--- a/mosaic/src/instructions/sign.rs
+++ b/mosaic/src/instructions/sign.rs
@@ -2,7 +2,7 @@ use crate::{
     ID,
     errors::MosaicError,
     instructions::{root_pda_check, signing_session_pda_check},
-    state::{root::Root, signing_session::SigningSession},
+    state::{PackUnpack, root::Root, signing_session::SigningSession},
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use pinocchio::{
@@ -93,7 +93,7 @@ impl<'info> TryFrom<(&'info [AccountView], &'info [u8])> for Sign<'info> {
 impl<'info> Sign<'info> {
     pub fn handler(&mut self) -> ProgramResult {
         let root_account = &self.accounts.root.try_borrow()?;
-        let root_data = Root::deserialize(&root_account)?;
+        let root_data = Root::unpack(&root_account)?;
 
         signing_session_pda_check(
             &self.accounts.signing_session.address(),
@@ -103,7 +103,7 @@ impl<'info> Sign<'info> {
         )?;
 
         let signing_account = self.accounts.signing_session.try_borrow()?;
-        let mut signing: SigningSession = SigningSession::deserialize(&signing_account)?;
+        let mut signing: SigningSession = SigningSession::unpack(&signing_account)?;
 
         root_pda_check(&self.accounts.root.address(), &[root_data.bump])?;
         Self::mandatory_account_data_checks(&signing, &root_data, self.accounts.payer.address())?;
@@ -114,7 +114,7 @@ impl<'info> Sign<'info> {
             signing.progress_phase_checked()?;
         }
 
-        let (signing, new_signing_len) = signing.serialize()?;
+        let (signing, new_signing_len) = signing.pack()?;
         let current_data_len = signing_account.len();
 
         if new_signing_len != current_data_len {

--- a/mosaic/src/state/mod.rs
+++ b/mosaic/src/state/mod.rs
@@ -1,2 +1,18 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use pinocchio::error::ProgramError;
+
 pub mod root;
 pub mod signing_session;
+
+pub trait PackUnpack: BorshDeserialize + BorshSerialize {
+    /// returns serialized data with length
+    fn pack(&self) -> Result<(Vec<u8>, usize), ProgramError> {
+        let data = borsh::to_vec(&self).map_err(|_| ProgramError::InvalidAccountData)?;
+        let size = data.len();
+        Ok((data, size))
+    }
+    /// returns deserialized data
+    fn unpack(data: &[u8]) -> Result<Self, ProgramError> {
+        borsh::from_slice(&data).map_err(|_| ProgramError::InvalidAccountData)
+    }
+}

--- a/mosaic/src/state/root.rs
+++ b/mosaic/src/state/root.rs
@@ -1,4 +1,6 @@
-use crate::{errors::MosaicError, instructions::init_root::InitializeRootIxData};
+use crate::{
+    errors::MosaicError, instructions::init_root::InitializeRootIxData, state::PackUnpack,
+};
 use pinocchio::{Address, error::ProgramError};
 
 /// root data
@@ -63,15 +65,4 @@ impl Root {
     }
 }
 
-impl Root {
-    /// returns serialized data with length
-    pub fn serialize(&self) -> Result<(Vec<u8>, usize), ProgramError> {
-        let data = borsh::to_vec(&self).map_err(|_| ProgramError::InvalidAccountData)?;
-        let size = data.len();
-        Ok((data, size))
-    }
-    /// returns deserialized data
-    pub fn deserialize(data: &[u8]) -> Result<Self, ProgramError> {
-        borsh::from_slice(&data).map_err(|_| ProgramError::InvalidAccountData)
-    }
-}
+impl PackUnpack for Root {}

--- a/mosaic/src/state/signing_session.rs
+++ b/mosaic/src/state/signing_session.rs
@@ -1,5 +1,6 @@
 use crate::{
     errors::MosaicError, instructions::init_signing_session::InitializeSigningSessionIxData,
+    state::PackUnpack,
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use pinocchio::{Address, error::ProgramError};
@@ -151,15 +152,4 @@ impl SigningSession {
     }
 }
 
-impl SigningSession {
-    /// returns serialized data with length
-    pub fn serialize(&self) -> Result<(Vec<u8>, usize), ProgramError> {
-        let data = borsh::to_vec(&self).map_err(|_| ProgramError::InvalidAccountData)?;
-        let size = data.len();
-        Ok((data, size))
-    }
-
-    pub fn deserialize(data: &[u8]) -> Result<Self, ProgramError> {
-        borsh::from_slice(&data).map_err(|_| ProgramError::InvalidAccountData)
-    }
-}
+impl PackUnpack for SigningSession {}


### PR DESCRIPTION
### Description
To reduce code repetition, the PackUnpack trait was introduced.

### Summary of changes
- Both state structures, `Root` and `SigningSession`, now get default implementations from the trait.