### PR TITLE
add close session account instruction

### DIFF
--- a/mosaic/src/errors.rs
+++ b/mosaic/src/errors.rs
@@ -3,6 +3,7 @@ use pinocchio::error::ProgramError;
 #[derive(Debug, Clone, PartialEq)]
 pub enum MosaicError {
     PayerMustEqualSigner = 6000,
+    PayerAccountMustBeWritable,
     RootAccountMustBeWrittable,
     RootAccountMustBeInitialized,
     RootAccountMustNotBeInitialized,
@@ -29,6 +30,9 @@ impl std::fmt::Display for MosaicError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             MosaicError::PayerMustEqualSigner => write!(f, "payer and signer must equal"),
+            MosaicError::PayerAccountMustBeWritable => {
+                write!(f, "payer account must be writable")
+            }
             MosaicError::RootAccountMustBeWrittable => {
                 write!(f, "root account must be writtable")
             }

--- a/mosaic/src/instructions/close_session_account.rs
+++ b/mosaic/src/instructions/close_session_account.rs
@@ -1,0 +1,133 @@
+use crate::{
+    ID,
+    errors::MosaicError,
+    instructions::{root_pda_check, signing_session_pda_check},
+    state::{PackUnpack, root::Root, signing_session::SigningSession},
+};
+use pinocchio::{AccountView, ProgramResult, error::ProgramError};
+
+/// Close Session Account
+///
+/// ### accounts:
+///   0. `[WRITE, SIGNER]` payer (lamports recipient)
+///   1. `[READ]` root pda
+///   2. `[WRITE]` signing session pda
+pub struct CloseSessionAccountIxAccounts<'info> {
+    pub payer: &'info AccountView,
+    pub root: &'info AccountView,
+    pub signing_session: &'info AccountView,
+}
+
+impl<'info> TryFrom<&'info [AccountView]> for CloseSessionAccountIxAccounts<'info> {
+    type Error = ProgramError;
+
+    fn try_from(accounts: &'info [AccountView]) -> Result<Self, Self::Error> {
+        let [payer, root, signing_session] = accounts else {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        };
+
+        if !root.owned_by(&ID.into()) {
+            return Err(MosaicError::RootAccountIncorrectOwner.into());
+        }
+        if !signing_session.owned_by(&ID.into()) {
+            return Err(MosaicError::SigningSessionAccountIncorrectOwner.into());
+        }
+        if !payer.is_signer() {
+            return Err(MosaicError::PayerMustEqualSigner.into());
+        }
+        if !signing_session.is_writable() {
+            return Err(MosaicError::SigningSessionAccountMustBeWritable.into());
+        }
+        if signing_session.is_data_empty() {
+            return Err(MosaicError::SigningSessionAccountMustBeInitialized.into());
+        }
+        if payer.address() == signing_session.address() {
+            return Err(ProgramError::InvalidArgument);
+        }
+
+        Ok(Self {
+            payer,
+            root,
+            signing_session,
+        })
+    }
+}
+
+#[derive(Clone, Copy, borsh::BorshSerialize, borsh::BorshDeserialize)]
+pub struct CloseSessionAccountIxData {}
+
+impl<'info> TryFrom<&'info [u8]> for CloseSessionAccountIxData {
+    type Error = ProgramError;
+
+    fn try_from(data: &'info [u8]) -> Result<Self, Self::Error> {
+        Ok(borsh::from_slice::<Self>(&data).map_err(|_| ProgramError::InvalidInstructionData)?)
+    }
+}
+
+pub struct CloseSessionAccount<'info> {
+    pub accounts: CloseSessionAccountIxAccounts<'info>,
+    pub instruction_data: CloseSessionAccountIxData,
+}
+
+impl<'info> TryFrom<(&'info [AccountView], &'info [u8])> for CloseSessionAccount<'info> {
+    type Error = ProgramError;
+
+    fn try_from(
+        (accounts, data): (&'info [AccountView], &'info [u8]),
+    ) -> Result<Self, Self::Error> {
+        let accounts = CloseSessionAccountIxAccounts::try_from(accounts)?;
+        let instruction_data = CloseSessionAccountIxData::try_from(data)?;
+
+        Ok(Self {
+            accounts,
+            instruction_data,
+        })
+    }
+}
+
+impl<'info> CloseSessionAccount<'info> {
+    pub fn handler(&mut self) -> ProgramResult {
+        let root_data = {
+            let root_account = self.accounts.root.try_borrow()?;
+            Root::unpack(&root_account)?
+        };
+        // TODO: this could be optimized to read just single byte to avoid deserializtion cost
+        let signing_data = {
+            let signing_account = self.accounts.signing_session.try_borrow()?;
+            SigningSession::unpack(&signing_account)?
+        };
+
+        root_pda_check(&self.accounts.root.address(), &[root_data.bump])?;
+        signing_session_pda_check(
+            &self.accounts.signing_session.address(),
+            self.accounts.root.address().as_array(),
+            signing_data.session_id,
+            &[signing_data.bump],
+        )?;
+        Self::mandatory_checks(&root_data, &signing_data, self.accounts.payer.address())?;
+
+        let signing_lamports = self.accounts.signing_session.lamports();
+        let payer_new_lamports = self
+            .accounts
+            .payer
+            .lamports()
+            .checked_add(signing_lamports)
+            .ok_or(ProgramError::ArithmeticOverflow)?;
+
+        self.accounts.payer.set_lamports(payer_new_lamports);
+        self.accounts.signing_session.close()?;
+
+        Ok(())
+    }
+
+    #[must_use]
+    fn mandatory_checks(
+        root: &Root,
+        signing_session: &SigningSession,
+        signer: &pinocchio::Address,
+    ) -> Result<(), ProgramError> {
+        root.signer_must_be_operator(signer)?;
+        signing_session.must_be_executed()?;
+        Ok(())
+    }
+}

--- a/mosaic/src/instructions/close_session_account.rs
+++ b/mosaic/src/instructions/close_session_account.rs
@@ -35,6 +35,9 @@ impl<'info> TryFrom<&'info [AccountView]> for CloseSessionAccountIxAccounts<'inf
         if !payer.is_signer() {
             return Err(MosaicError::PayerMustEqualSigner.into());
         }
+        if !payer.is_writable() {
+            return Err(MosaicError::PayerAccountMustBeWritable.into());
+        }
         if !signing_session.is_writable() {
             return Err(MosaicError::SigningSessionAccountMustBeWritable.into());
         }

--- a/mosaic/src/instructions/mod.rs
+++ b/mosaic/src/instructions/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     ID, {ROOT_PDA, SIGNING_SESSION_PDA},
 };
 
+pub mod close_session_account;
 pub mod execute;
 pub mod init_root;
 pub mod init_signing_session;
@@ -15,6 +16,7 @@ pub enum Instruction {
     InitializeSigningSession,
     Sign,
     Execute,
+    CloseSessionAccount,
 }
 
 impl TryFrom<&u8> for Instruction {
@@ -26,6 +28,7 @@ impl TryFrom<&u8> for Instruction {
             1 => Ok(Instruction::InitializeSigningSession),
             2 => Ok(Instruction::Sign),
             3 => Ok(Instruction::Execute),
+            4 => Ok(Instruction::CloseSessionAccount),
             _ => Err(ProgramError::InvalidInstructionData),
         }
     }

--- a/mosaic/src/lib.rs
+++ b/mosaic/src/lib.rs
@@ -3,8 +3,8 @@ pub mod instructions;
 pub mod state;
 
 use crate::instructions::{
-    Instruction, execute::Execute, init_root::InitializeOperators,
-    init_signing_session::InitializeSigningSession, sign::Sign,
+    Instruction, close_session_account::CloseSessionAccount, execute::Execute,
+    init_root::InitializeOperators, init_signing_session::InitializeSigningSession, sign::Sign,
 };
 use pinocchio::{AccountView, Address, ProgramResult, error::ProgramError, program_entrypoint};
 use solana_program::{custom_heap_default, custom_panic_default};
@@ -40,6 +40,9 @@ pub fn process_instruction(
         }
         Instruction::Sign => Sign::try_from((accounts, data))?.handler(),
         Instruction::Execute => Execute::try_from((accounts, data))?.handler(),
+        Instruction::CloseSessionAccount => {
+            CloseSessionAccount::try_from((accounts, data))?.handler()
+        }
     }
 }
 

--- a/mosaic/src/state/signing_session.rs
+++ b/mosaic/src/state/signing_session.rs
@@ -139,6 +139,13 @@ impl SigningSession {
             .ok_or(MosaicError::SigningSessionPhaseIncorrect.into())
     }
 
+    /// checks if signing session is executed
+    pub fn must_be_executed(&self) -> Result<(), ProgramError> {
+        (self.phase == SigningSessionPhase::Executed)
+            .then_some(())
+            .ok_or(MosaicError::SigningSessionPhaseIncorrect.into())
+    }
+
     /// checks if root last id equals the session id
     pub fn sessions_must_equal(&self, root_last_id: u16) -> Result<(), ProgramError> {
         (self.session_id == root_last_id)

--- a/mosaic/tests/close_session_account.rs
+++ b/mosaic/tests/close_session_account.rs
@@ -1,0 +1,104 @@
+mod common;
+
+use {
+    borsh::to_vec,
+    common::*,
+    mollusk_svm::{Mollusk, result::Check},
+};
+
+use mosaic::{
+    instructions::{Instruction as ProgramIx, close_session_account::CloseSessionAccountIxData},
+    state::signing_session::SigningSessionPhase,
+};
+
+use solana_sdk::{
+    account::ReadableAccount,
+    instruction::{AccountMeta, Instruction},
+};
+
+#[test]
+fn test_close_session_account() {
+    let mollusk = Mollusk::new(&PROGRAM_ID, MOSAIC_BINARY_PATH);
+
+    let (system_program, _) = mollusk_svm::program::keyed_account_for_system_program();
+
+    let operators = Operators::new(3, system_program);
+    let operators_pubkey: Vec<_> = operators
+        .operators
+        .iter()
+        .map(|operator| operator.0)
+        .collect();
+    let (signer, signer_account) = operators.operators[0].clone();
+
+    let session_id = 1;
+
+    let (
+        root_pda,
+        _root_pda_bump,
+        _root_pda_init_state,
+        _root_pda_initial_state_serialized,
+        root_account,
+    ) = prepare_root(
+        &mollusk,
+        operators,
+        operators_pubkey.clone(),
+        session_id,
+        DESTINATION_PROGRAM_ID.as_ref().try_into().unwrap(),
+    );
+
+    let (storage_pda, _storage_pda_account) =
+        prepare_storage_account(&mollusk, session_id, root_pda);
+    let (cpi_instruction_accounts, cpi_instruction_data) =
+        records_program_ix_accs(storage_pda, root_pda);
+
+    let (signing_pda, _signing_pda_bump, _signing_init_state_serialized, signing_account) =
+        prepare_signing_session(
+            &mollusk,
+            session_id,
+            root_pda,
+            vec![signer, operators_pubkey[1]],
+            SigningSessionPhase::Executed,
+            cpi_instruction_accounts,
+            cpi_instruction_data,
+        );
+
+    let payer_initial_lamports = signer_account.lamports();
+    let signing_initial_lamports = signing_account.lamports();
+
+    let ix_data = CloseSessionAccountIxData {};
+    let data = [
+        vec![ProgramIx::CloseSessionAccount as u8],
+        to_vec(&ix_data).unwrap(),
+    ]
+    .concat();
+
+    let instruction = Instruction::new_with_bytes(
+        PROGRAM_ID,
+        &data,
+        vec![
+            AccountMeta::new(signer.into(), true),
+            AccountMeta::new_readonly(root_pda, false),
+            AccountMeta::new(signing_pda, false),
+        ],
+    );
+
+    let result: mollusk_svm::result::InstructionResult = mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (signer.into(), signer_account.clone().into()),
+            (root_pda, root_account.clone().into()),
+            (signing_pda, signing_account.clone().into()),
+        ],
+        &[Check::success()],
+    );
+
+    let updated_payer = result.get_account(&signer).unwrap();
+    let updated_signing = result.get_account(&signing_pda).unwrap();
+
+    assert_eq!(
+        updated_payer.lamports,
+        payer_initial_lamports + signing_initial_lamports
+    );
+    assert_eq!(updated_signing.lamports, 0);
+    assert!(updated_signing.data.is_empty());
+}

--- a/mosaic/tests/close_session_account_failures.rs
+++ b/mosaic/tests/close_session_account_failures.rs
@@ -13,8 +13,11 @@ use mosaic::{
 };
 
 use solana_sdk::{
+    account::AccountSharedData,
     instruction::{AccountMeta, Instruction},
+    native_token::LAMPORTS_PER_SOL,
     program_error::ProgramError,
+    pubkey::Pubkey,
 };
 
 #[test]
@@ -163,6 +166,83 @@ fn test_close_session_account_phase_is_not_executed_failure() {
         ],
         &[Check::err(ProgramError::Custom(
             MosaicError::SigningSessionPhaseIncorrect as u32,
+        ))],
+    );
+}
+
+#[test]
+fn test_close_session_account_signer_is_not_operator_failure() {
+    let mollusk = Mollusk::new(&PROGRAM_ID, MOSAIC_BINARY_PATH);
+    let (system_program, _) = mollusk_svm::program::keyed_account_for_system_program();
+
+    let operators = Operators::new(3, system_program);
+    let operators_pubkey: Vec<_> = operators
+        .operators
+        .iter()
+        .map(|operator| operator.0)
+        .collect();
+    let not_operator_signer = Pubkey::new_unique();
+    let not_operator_signer_account =
+        AccountSharedData::new(1 * LAMPORTS_PER_SOL, 0, &system_program);
+
+    let session_id = 1;
+
+    let (
+        root_pda,
+        _root_pda_bump,
+        _root_pda_init_state,
+        _root_pda_initial_state_serialized,
+        root_account,
+    ) = prepare_root(
+        &mollusk,
+        operators,
+        operators_pubkey.clone(),
+        session_id,
+        DESTINATION_PROGRAM_ID.as_ref().try_into().unwrap(),
+    );
+
+    let (storage_pda, _storage_pda_account) =
+        prepare_storage_account(&mollusk, session_id, root_pda);
+    let (cpi_instruction_accounts, cpi_instruction_data) =
+        records_program_ix_accs(storage_pda, root_pda);
+
+    let (signing_pda, _signing_pda_bump, _signing_init_state_serialized, signing_account) =
+        prepare_signing_session(
+            &mollusk,
+            session_id,
+            root_pda,
+            vec![operators_pubkey[0], operators_pubkey[1]],
+            SigningSessionPhase::Executed,
+            cpi_instruction_accounts,
+            cpi_instruction_data,
+        );
+
+    let ix_data = CloseSessionAccountIxData {};
+    let data = [
+        vec![ProgramIx::CloseSessionAccount as u8],
+        to_vec(&ix_data).unwrap(),
+    ]
+    .concat();
+
+    let instruction = Instruction::new_with_bytes(
+        PROGRAM_ID,
+        &data,
+        vec![
+            AccountMeta::new(not_operator_signer, true),
+            AccountMeta::new_readonly(root_pda, false),
+            AccountMeta::new(signing_pda, false),
+        ],
+    );
+
+    let _result: mollusk_svm::result::InstructionResult = mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (not_operator_signer, not_operator_signer_account.into()),
+            (root_pda, root_account.clone().into()),
+            (signing_pda, signing_account.clone().into()),
+        ],
+        &[Check::err(ProgramError::Custom(
+            MosaicError::SignerIsNotOperator as u32,
         ))],
     );
 }

--- a/mosaic/tests/close_session_account_failures.rs
+++ b/mosaic/tests/close_session_account_failures.rs
@@ -1,0 +1,168 @@
+mod common;
+
+use {
+    borsh::to_vec,
+    common::*,
+    mollusk_svm::{Mollusk, result::Check},
+};
+
+use mosaic::{
+    errors::MosaicError,
+    instructions::{Instruction as ProgramIx, close_session_account::CloseSessionAccountIxData},
+    state::signing_session::SigningSessionPhase,
+};
+
+use solana_sdk::{
+    instruction::{AccountMeta, Instruction},
+    program_error::ProgramError,
+};
+
+#[test]
+fn test_close_session_account_payer_is_not_signer_failure() {
+    let mollusk = Mollusk::new(&PROGRAM_ID, MOSAIC_BINARY_PATH);
+    let (system_program, _) = mollusk_svm::program::keyed_account_for_system_program();
+
+    let operators = Operators::new(3, system_program);
+    let operators_pubkey: Vec<_> = operators
+        .operators
+        .iter()
+        .map(|operator| operator.0)
+        .collect();
+    let (payer, payer_account) = operators.operators[0].clone();
+
+    let session_id = 1;
+
+    let (
+        root_pda,
+        _root_pda_bump,
+        _root_pda_init_state,
+        _root_pda_initial_state_serialized,
+        root_account,
+    ) = prepare_root(
+        &mollusk,
+        operators,
+        operators_pubkey.clone(),
+        session_id,
+        DESTINATION_PROGRAM_ID.as_ref().try_into().unwrap(),
+    );
+
+    let (storage_pda, _storage_pda_account) =
+        prepare_storage_account(&mollusk, session_id, root_pda);
+    let (cpi_instruction_accounts, cpi_instruction_data) =
+        records_program_ix_accs(storage_pda, root_pda);
+
+    let (signing_pda, _signing_pda_bump, _signing_init_state_serialized, signing_account) =
+        prepare_signing_session(
+            &mollusk,
+            session_id,
+            root_pda,
+            vec![payer, operators_pubkey[1]],
+            SigningSessionPhase::Executed,
+            cpi_instruction_accounts,
+            cpi_instruction_data,
+        );
+
+    let ix_data = CloseSessionAccountIxData {};
+    let data = [
+        vec![ProgramIx::CloseSessionAccount as u8],
+        to_vec(&ix_data).unwrap(),
+    ]
+    .concat();
+
+    let instruction = Instruction::new_with_bytes(
+        PROGRAM_ID,
+        &data,
+        vec![
+            AccountMeta::new(payer.into(), false),
+            AccountMeta::new_readonly(root_pda, false),
+            AccountMeta::new(signing_pda, false),
+        ],
+    );
+
+    let _result: mollusk_svm::result::InstructionResult = mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (payer.into(), payer_account.clone().into()),
+            (root_pda, root_account.clone().into()),
+            (signing_pda, signing_account.clone().into()),
+        ],
+        &[Check::err(ProgramError::Custom(
+            MosaicError::PayerMustEqualSigner as u32,
+        ))],
+    );
+}
+
+#[test]
+fn test_close_session_account_phase_is_not_executed_failure() {
+    let mollusk = Mollusk::new(&PROGRAM_ID, MOSAIC_BINARY_PATH);
+    let (system_program, _) = mollusk_svm::program::keyed_account_for_system_program();
+
+    let operators = Operators::new(3, system_program);
+    let operators_pubkey: Vec<_> = operators
+        .operators
+        .iter()
+        .map(|operator| operator.0)
+        .collect();
+    let (signer, signer_account) = operators.operators[0].clone();
+
+    let session_id = 1;
+
+    let (
+        root_pda,
+        _root_pda_bump,
+        _root_pda_init_state,
+        _root_pda_initial_state_serialized,
+        root_account,
+    ) = prepare_root(
+        &mollusk,
+        operators,
+        operators_pubkey.clone(),
+        session_id,
+        DESTINATION_PROGRAM_ID.as_ref().try_into().unwrap(),
+    );
+
+    let (storage_pda, _storage_pda_account) =
+        prepare_storage_account(&mollusk, session_id, root_pda);
+    let (cpi_instruction_accounts, cpi_instruction_data) =
+        records_program_ix_accs(storage_pda, root_pda);
+
+    let (signing_pda, _signing_pda_bump, _signing_init_state_serialized, signing_account) =
+        prepare_signing_session(
+            &mollusk,
+            session_id,
+            root_pda,
+            vec![signer, operators_pubkey[1]],
+            SigningSessionPhase::Approved,
+            cpi_instruction_accounts,
+            cpi_instruction_data,
+        );
+
+    let ix_data = CloseSessionAccountIxData {};
+    let data = [
+        vec![ProgramIx::CloseSessionAccount as u8],
+        to_vec(&ix_data).unwrap(),
+    ]
+    .concat();
+
+    let instruction = Instruction::new_with_bytes(
+        PROGRAM_ID,
+        &data,
+        vec![
+            AccountMeta::new(signer.into(), true),
+            AccountMeta::new_readonly(root_pda, false),
+            AccountMeta::new(signing_pda, false),
+        ],
+    );
+
+    let _result: mollusk_svm::result::InstructionResult = mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (signer.into(), signer_account.clone().into()),
+            (root_pda, root_account.clone().into()),
+            (signing_pda, signing_account.clone().into()),
+        ],
+        &[Check::err(ProgramError::Custom(
+            MosaicError::SigningSessionPhaseIncorrect as u32,
+        ))],
+    );
+}

--- a/mosaic/tests/execute_failures.rs
+++ b/mosaic/tests/execute_failures.rs
@@ -842,8 +842,7 @@ fn test_execute_destination_program_mismatch_failure() {
 
     // wrong destination program
     let wrong_destination_program = Pubkey::new_unique();
-    let wrong_dst_program_account =
-        AccountSharedData::new(0, 0, &solana_sdk::bpf_loader::id());
+    let wrong_dst_program_account = AccountSharedData::new(0, 0, &solana_sdk::bpf_loader::id());
 
     let ix_data_execute = ExecuteIxData {};
     let data_execute = [


### PR DESCRIPTION
### Description

This PR adds new instruction `Close Session Account` to retrieve signing sessions lamports after successful execution of the session payload.

