### PR TITLE
bugfix: execute reentry

### DIFF
--- a/mosaic/src/instructions/execute.rs
+++ b/mosaic/src/instructions/execute.rs
@@ -170,6 +170,15 @@ impl<'info> Execute<'info> {
             })
             .collect::<Result<_, _>>()?;
 
+        // Lock the session before external CPI to avoid a reentrancy window.
+        let mut signing_data = signing_data;
+        signing_data.progress_phase_checked()?; /* set signing session phase to executed */
+        let (serialized_data, serialized_len) = signing_data.pack()?;
+        {
+            let mut signing_account = self.accounts.signing_session.try_borrow_mut()?;
+            signing_account[..serialized_len].copy_from_slice(&serialized_data);
+        }
+
         // cpi to destination program
         let instruction = InstructionView {
             program_id: self.accounts._dst_program.address(),
@@ -177,14 +186,6 @@ impl<'info> Execute<'info> {
             data: &signing_data.instruction_data.clone(),
         };
         invoke_signed_dynamic!(&instruction, account_views, &[cpi_signer])?;
-
-        // update signing session / prevent re-execution
-        let mut signing_data = signing_data;
-        signing_data.progress_phase_checked()?; /* set signing session phase to executed */
-
-        let (serialized_data, serialized_len) = signing_data.pack()?;
-        let mut signing_account = self.accounts.signing_session.try_borrow_mut()?;
-        signing_account[..serialized_len].copy_from_slice(&serialized_data);
 
         Ok(())
     }

--- a/mosaic/src/instructions/execute.rs
+++ b/mosaic/src/instructions/execute.rs
@@ -39,6 +39,9 @@ impl<'info> TryFrom<&'info [AccountView]> for ExecuteIxAccounts<'info> {
 
     fn try_from(accounts: &'info [AccountView]) -> Result<Self, Self::Error> {
         // perform accounts attribute check
+        if accounts.len() < 5 {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
         let (required_accounts, remaining) = accounts.split_at(5);
         let [payer, root, signing_session, _sys_program, _dst_program] = required_accounts else {
             return Err(ProgramError::NotEnoughAccountKeys);

--- a/mosaic/tests/execute_failures.rs
+++ b/mosaic/tests/execute_failures.rs
@@ -880,3 +880,85 @@ fn test_execute_destination_program_mismatch_failure() {
         ))],
     );
 }
+
+#[test]
+fn test_execute_missing_remaining_account_rolls_back_phase() {
+    let mut mollusk = Mollusk::new(&PROGRAM_ID, MOSAIC_BINARY_PATH);
+    mollusk.add_program(&DESTINATION_PROGRAM_ID, "tests/spl_record");
+
+    let (system_program, system_account) = mollusk_svm::program::keyed_account_for_system_program();
+    let dst_program_account = AccountSharedData::new(0, 0, &solana_sdk::bpf_loader::id());
+
+    let operators = Operators::new(3, system_program);
+    let operators_pubkey: Vec<_> = operators
+        .operators
+        .iter()
+        .map(|operator| operator.0)
+        .collect();
+    let (signer, signer_account) = operators.operators[0].clone();
+
+    let session_id = 1;
+
+    let (root_pda, _, _, _, root_account) = prepare_root(
+        &mollusk,
+        operators,
+        operators_pubkey.clone(),
+        session_id,
+        DESTINATION_PROGRAM_ID.as_ref().try_into().unwrap(),
+    );
+
+    // Build CPI payload that expects a storage account in `remaining`.
+    let (storage_pda, _storage_pda_account) =
+        prepare_storage_account(&mollusk, session_id, root_pda);
+    let (cpi_instruction_accounts, cpi_instruction_data) =
+        records_program_ix_accs(storage_pda, root_pda);
+
+    let (signing_pda, _signing_pda_bump, _signing_init_state_serialized, signing_account) =
+        prepare_signing_session(
+            &mollusk,
+            session_id,
+            root_pda,
+            vec![signer, operators_pubkey[1]],
+            SigningSessionPhase::Approved,
+            cpi_instruction_accounts,
+            cpi_instruction_data,
+        );
+
+    let ix_data_execute = ExecuteIxData {};
+    let data_execute = [
+        vec![ProgramIx::Execute as u8],
+        to_vec(&ix_data_execute).unwrap(),
+    ]
+    .concat();
+
+    // Intentionally pass only the 5 required accounts and omit the storage account.
+    let instruction = Instruction::new_with_bytes(
+        PROGRAM_ID,
+        &data_execute,
+        vec![
+            AccountMeta::new(signer.into(), true),
+            AccountMeta::new_readonly(root_pda, false),
+            AccountMeta::new(signing_pda, false),
+            AccountMeta::new_readonly(system_program, false),
+            AccountMeta::new_readonly(DESTINATION_PROGRAM_ID, false),
+        ],
+    );
+
+    let result: mollusk_svm::result::InstructionResult = mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (signer.into(), signer_account.clone().into()),
+            (root_pda, root_account.clone().into()),
+            (signing_pda, signing_account.clone().into()),
+            (system_program, system_account.clone().into()),
+            (DESTINATION_PROGRAM_ID, dst_program_account.clone().into()),
+        ],
+        &[Check::err(ProgramError::NotEnoughAccountKeys)],
+    );
+
+    // If state is locked before CPI and call fails, rollback must keep phase unchanged.
+    let updated_signing_session_pda_account = result.get_account(&signing_pda).unwrap();
+    let parsed_signing_session_pda_data =
+        borsh::from_slice::<SigningSession>(&updated_signing_session_pda_account.data).unwrap();
+    assert!(parsed_signing_session_pda_data.phase == SigningSessionPhase::Approved);
+}

--- a/mosaic/tests/execute_failures.rs
+++ b/mosaic/tests/execute_failures.rs
@@ -21,6 +21,50 @@ use solana_sdk::{
 };
 
 #[test]
+fn test_execute_not_enough_accounts_failure() {
+    let mollusk = Mollusk::new(&PROGRAM_ID, MOSAIC_BINARY_PATH);
+    let (system_program, system_account) = mollusk_svm::program::keyed_account_for_system_program();
+
+    let payer = Pubkey::new_unique();
+    let root = Pubkey::new_unique();
+    let signing = Pubkey::new_unique();
+
+    let payer_account = AccountSharedData::new(1_000_000, 0, &system_program);
+    let root_account = AccountSharedData::new(0, 0, &PROGRAM_ID);
+    let signing_account = AccountSharedData::new(0, 0, &PROGRAM_ID);
+
+    let ix_data_execute = ExecuteIxData {};
+    let data_execute = [
+        vec![ProgramIx::Execute as u8],
+        to_vec(&ix_data_execute).unwrap(),
+    ]
+    .concat();
+
+    // only 4 accounts; execute requires at least 5
+    let instruction = Instruction::new_with_bytes(
+        PROGRAM_ID,
+        &data_execute,
+        vec![
+            AccountMeta::new(payer, true),
+            AccountMeta::new_readonly(root, false),
+            AccountMeta::new(signing, false),
+            AccountMeta::new_readonly(system_program, false),
+        ],
+    );
+
+    let _result: mollusk_svm::result::InstructionResult = mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (payer, payer_account.into()),
+            (root, root_account.into()),
+            (signing, signing_account.into()),
+            (system_program, system_account.into()),
+        ],
+        &[Check::err(ProgramError::NotEnoughAccountKeys)],
+    );
+}
+
+#[test]
 fn test_execute_payer_is_not_signer_failure() {
     let mut mollusk = Mollusk::new(&PROGRAM_ID, MOSAIC_BINARY_PATH);
     mollusk.add_program(&DESTINATION_PROGRAM_ID, "tests/spl_record");
@@ -836,4 +880,3 @@ fn test_execute_destination_program_mismatch_failure() {
         ))],
     );
 }
-


### PR DESCRIPTION
### Description
Execute performed CPI to the destination program first, and only then moved session phase to Executed.
That created a reentrancy window where a destination program could attempt a callback before the session was locked.

### Changes
- Updated execute flow to set and persist SigningSession phase to Executed before CPI.
Added comments documenting why pre-CPI locking is required and why rollback keeps behavior safe on failure
- Added tests